### PR TITLE
feat(docs): Add documentation for Newsky

### DIFF
--- a/src/pages/msfs/utils/newsky.mdx
+++ b/src/pages/msfs/utils/newsky.mdx
@@ -1,14 +1,15 @@
 import { Callout } from 'nextra/components';
 import { Steps } from 'nextra-theme-docs';
 
-# NewSky
+# Newsky
 
 [Newsky](https://newsky.app/) is a client for virtual airlines to book, track, and manage flights.
 
 <Callout type="warning" emoji="⚠️">
-Whilst Newsky can work on Linux, their official stance is that it is unsupported. It is "planned", so hopefully
-they do not intentionally break anything, there is no guarantee, and do not expect support from Newsky on
-running with Linux.
+This software is only supported on Windows. Whilst Newsky says official Linux and Mac support is 
+"planned at some point", currently it is "not yet" supported, and though it has been able to be run
+on Linux, there is no guarantee that this will work later down the line. Do not expect, or ask for,
+support from Newsky.
 </Callout>
 
 ## Installation
@@ -20,7 +21,7 @@ running with Linux.
 Newsky can have issues launching alongside MSFS when running using protontricks. To get around this,
 Newsky can be launched using Wine, and then use a networked SimConnect session to connect to MSFS.
 
-<steps>
+<Steps>
 
 ### Download and run the Newsky installer
 
@@ -39,7 +40,7 @@ I chose 8381, other ports may/may not work for you, but this worked for me.
 
 ### Enable Networked SimConnect for MSFS
 
-Navigate to `PATH/TO/COMPDATA/1250410/pfx/drive_c/users/steamuser/AppData/Roaming/Microsoft\ Flight\Simulator`
+Navigate to `PATH/TO/COMPDATA/1250410/pfx/drive_c/users/steamuser/AppData/Roaming/Microsoft\ Flight\ Simulator`
 
 Open SimConnect.xml in a text editor of your choice
 
@@ -62,5 +63,9 @@ Now launch MSFS, and Newsky should be able to connect to the simulator. The text
 of the loading screen, or on the main menu. If it does not change, check that the ports match, or try another
 port.
 
-There should be no need to create a desktop icon yourself, as Winetricks should have created it for you.
-</steps>
+### (Optional) Desktop entry
+
+There should be no need to create a desktop file yourself, as Winetricks should have created it for you.
+If you want to modify the .desktop file, it is located in `~/.local/share/applications/wine/programs`.
+
+</Steps>

--- a/src/pages/msfs/utils/newsky.mdx
+++ b/src/pages/msfs/utils/newsky.mdx
@@ -2,11 +2,11 @@ import { Callout } from 'nextra/components';
 import { Steps } from 'nextra-theme-docs';
 
 # NewSky
+
 [Newsky](https://newsky.app/) is a client for virtual airlines to book, track, and manage flights.
 
 <Callout type="warning" emoji="⚠️">
-Whilst Newsky can work on Linux, their [official stance]
-(https://wiki.newsky.app/#is-maclinux-supported) is that it is unsupported. It is "planned", so hopefully
+Whilst Newsky can work on Linux, their official stance is that it is unsupported. It is "planned", so hopefully
 they do not intentionally break anything, there is no guarantee, and do not expect support from Newsky on
 running with Linux.
 </Callout>
@@ -17,7 +17,7 @@ running with Linux.
 **Difficulty:** easy-medium
 </Callout>
 
-Newsky can have issues launching alongside MSFS when running using protontricks, to get around this,
+Newsky can have issues launching alongside MSFS when running using protontricks. To get around this,
 Newsky can be launched using Wine, and then use a networked SimConnect session to connect to MSFS.
 
 <steps>
@@ -45,7 +45,8 @@ Open SimConnect.xml in a text editor of your choice
 
 Create a new SimConnect.comm section, where PORT is the port that was set in Newsky:
 
-`<SimConnect.Comm>
+```shell copy
+    <SimConnect.Comm>
         <Descr>Static IP4 port</Descr>
         <Protocol>IPv4</Protocol>
         <Address>127.0.0.1</Address>
@@ -53,7 +54,8 @@ Create a new SimConnect.comm section, where PORT is the port that was set in New
         <Port>8381</Port>
         <MaxClients>64</MaxClients>
         <MaxRecvSize>41088</MaxRecvSize>
-    </SimConnect.Comm>`
+    </SimConnect.Comm>
+    ```
 
 Now launch MSFS, and Newsky should be able to connect to the simulator. The text in the top left saying
 "waiting for sim connection" should change to "connected to simulator", and will show during towards the end

--- a/src/pages/msfs/utils/newsky.mdx
+++ b/src/pages/msfs/utils/newsky.mdx
@@ -1,0 +1,64 @@
+import { Callout } from 'nextra/components';
+import { Steps } from 'nextra-theme-docs';
+
+# NewSky
+[Newsky](https://newsky.app/) is a client for virtual airlines to book, track, and manage flights.
+
+<Callout type="warning" emoji="⚠️">
+Whilst Newsky can work on Linux, their [official stance]
+(https://wiki.newsky.app/#is-maclinux-supported) is that it is unsupported. It is "planned", so hopefully
+they do not intentionally break anything, there is no guarantee, and do not expect support from Newsky on
+running with Linux.
+</Callout>
+
+## Installation
+
+<Callout type="info" emoji="ℹ️">
+**Difficulty:** easy-medium
+</Callout>
+
+Newsky can have issues launching alongside MSFS when running using protontricks, to get around this,
+Newsky can be launched using Wine, and then use a networked SimConnect session to connect to MSFS.
+
+<steps>
+
+### Download and run the Newsky installer
+
+You can download the Newsky installer from the link on [their website](https://newsky.app/).
+
+Open Winetricks (not Protontricks), select the default prefix which should show up in the window 
+titlebar under /home/USER/.wine. Then select to run an arbitrary executable, find the Newsky installer
+you downloaded, and run the installer. Once Newsky has finished installing, it should have added a shortcut
+in your application launcher, and opens automatically.
+
+Sign into Newsky, then click on your user profile in the top right, and open settings. Scroll down until 
+you reach the "Networked setup" setup.
+
+Enable the Networked setup, and select MSFS as the simulator, 127.0.0.1 as the IP address, and a free port.
+I chose 8381, other ports may/may not work for you, but this worked for me.
+
+### Enable Networked SimConnect for MSFS
+
+Navigate to `PATH/TO/COMPDATA/1250410/pfx/drive_c/users/steamuser/AppData/Roaming/Microsoft\ Flight\Simulator`
+
+Open SimConnect.xml in a text editor of your choice
+
+Create a new SimConnect.comm section, where PORT is the port that was set in Newsky:
+
+`<SimConnect.Comm>
+        <Descr>Static IP4 port</Descr>
+        <Protocol>IPv4</Protocol>
+        <Address>127.0.0.1</Address>
+        <Scope>global</Scope>
+        <Port>8381</Port>
+        <MaxClients>64</MaxClients>
+        <MaxRecvSize>41088</MaxRecvSize>
+    </SimConnect.Comm>`
+
+Now launch MSFS, and Newsky should be able to connect to the simulator. The text in the top left saying
+"waiting for sim connection" should change to "connected to simulator", and will show during towards the end
+of the loading screen, or on the main menu. If it does not change, check that the ports match, or try another
+port.
+
+There should be no need to create a desktop icon yourself, as Winetricks should have created it for you.
+</steps>


### PR DESCRIPTION
Add install instructions for Newsky.

I considered adding more details on networked SimConnect, but left that out and just used 127.0.0.1 as the address. 