### PR TITLE
feat(hardware): add clarification what registry type to add for honeycomb bravo

### DIFF
--- a/src/pages/msfs/hardware/honeycomb-bravo.mdx
+++ b/src/pages/msfs/hardware/honeycomb-bravo.mdx
@@ -50,7 +50,7 @@ Create the following DWORD values:
 ### (Optional) Correct already registered device
 
 If you already started MSFS with the Honeycomb Bravo plugged in, it's likely been registered as an XBOX controller.
-regex
+
 You can fix this by editing the following registry key: `HKEY_LOCAL_MACHINE\System\CurrentControlSet\Enum\WINEBUS`
 
 #### Reset values of existing xinput entries to winehid

--- a/src/pages/msfs/hardware/honeycomb-bravo.mdx
+++ b/src/pages/msfs/hardware/honeycomb-bravo.mdx
@@ -44,13 +44,13 @@ Create the following DWORD values:
 - Name: Map Controllers Value: 0
 
 <Callout type="warning" emoji="⚠️">
-  For MSFS 2024 creating these keys as DWORD causes all peripherals to disappear besides mouse and keyboard, instead, create them as STRING. 
+  For MSFS 2024 creating these keys as `DWORD` causes all peripherals to disappear besides mouse and keyboard, instead, create them as `String`. 
 </Callout>
 
 ### (Optional) Correct already registered device
 
 If you already started MSFS with the Honeycomb Bravo plugged in, it's likely been registered as an XBOX controller.
-
+regex
 You can fix this by editing the following registry key: `HKEY_LOCAL_MACHINE\System\CurrentControlSet\Enum\WINEBUS`
 
 #### Reset values of existing xinput entries to winehid

--- a/src/pages/msfs/hardware/honeycomb-bravo.mdx
+++ b/src/pages/msfs/hardware/honeycomb-bravo.mdx
@@ -43,6 +43,10 @@ Create the following DWORD values:
 - Name: Enable SDL Value: 0
 - Name: Map Controllers Value: 0
 
+<Callout type="warning" emoji="⚠️">
+  For MSFS 2024 creating these keys as DWORD causes all peripherals to disappear besides mouse and keyboard, instead, create them as STRING. 
+</Callout>
+
 ### (Optional) Correct already registered device
 
 If you already started MSFS with the Honeycomb Bravo plugged in, it's likely been registered as an XBOX controller.


### PR DESCRIPTION
Hello, I just stumbled across this guide and would like to contribute an update for something I found while getting my hardware to work on msfs 2024. Each step works for msfs 2024 except for the creation of the DWORD keys for Enable SDL and Map Controllers, where all peripherals except mouse and keyboard would not show up after adding the keys. Instead I created them as STRING.