### PR TITLE
feat(docs): troubleshooting for download errors in Navigraph Hub

### DIFF
--- a/src/pages/msfs/utils/navigraph-hub.mdx
+++ b/src/pages/msfs/utils/navigraph-hub.mdx
@@ -75,13 +75,14 @@ update-desktop-database ~/.local/share/applications
 
 You should now be able to find Navigraph Hub in your Desktop Environment's application launcher.
 
-### Troubleshooting
-#### Installing anything from Navigraph Hub fails with a `Win32Exception`
+</Steps>
+
+## Troubleshooting
+### Installing anything from Navigraph Hub fails with a `Win32Exception`
 As per [a post on the Navigraph forums](https://forum.navigraph.com/t/cannot-install-anything-on-linux-workaround/22769),
-procgov.exe doesn't work as it calls a function that is incorrectly implemented in wine-win32.
-However, if procgov.exe isn't found, Navigraph Hub will resort to using 7z, which works just fine. Therefore, just navigate
+`procgov.exe` doesn't work as it calls a function that is incorrectly implemented in wine-win32.
+
+However, if `procgov.exe` isn't found, Navigraph Hub will resort to using 7z, which works just fine. Therefore, just navigate
  into the directory where Navigraph Hub is installed 
 (`.../steamapps/compatdata/1250410/pfx/drive_c/users/steamuser/AppData/Local/Programs/navigraph-hub/resources/assets/bin`)
- and move or delete procgov.exe. Navigraph Hub should now be able to install everything. 
-
-</Steps>
+ and move or delete `procgov.exe`. Navigraph Hub should now be able to install everything.

--- a/src/pages/msfs/utils/navigraph-hub.mdx
+++ b/src/pages/msfs/utils/navigraph-hub.mdx
@@ -75,4 +75,13 @@ update-desktop-database ~/.local/share/applications
 
 You should now be able to find Navigraph Hub in your Desktop Environment's application launcher.
 
+### Troubleshooting
+#### Installing anything from Navigraph Hub fails with a `Win32Exception`
+As per [a post on the Navigraph forums](https://forum.navigraph.com/t/cannot-install-anything-on-linux-workaround/22769),
+procgov.exe doesn't work as it calls a function that is incorrectly implemented in wine-win32.
+However, if procgov.exe isn't found, Navigraph Hub will resort to using 7z, which works just fine. Therefore, just navigate
+ into the directory where Navigraph Hub is installed 
+(`.../steamapps/compatdata/1250410/pfx/drive_c/users/steamuser/AppData/Local/Programs/navigraph-hub/resources/assets/bin`)
+ and move or delete procgov.exe. Navigraph Hub should now be able to install everything. 
+
 </Steps>


### PR DESCRIPTION
Installing things from Navigraph Hub kept failing on CachyOS for me, but I found [a post](https://forum.navigraph.com/t/cannot-install-anything-on-linux-workaround/22769) (not mine) on the Navigraph forums where someone had found a fix  (force Navigraph Hub to use 7z instead of procgov.exe). Given I'm not sure if the post will stick around forever, I figured it might be useful to preserve here. 